### PR TITLE
🐳 Add Docker Compose setup for Kafka and Redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,107 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+# Gradle
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+# STS (Spring Tool Suite)
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+# IntelliJ IDEA
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+# NetBeans
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+# VS Code
+.vscode/
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Docker
+.docker/
+
+# Spring Boot
+*.pid
+
+# Application properties (if contains sensitive info)
+# Uncomment if you want to ignore local config
+# application-local.properties
+# application-dev.properties
+
+# Logs
+logs/
+*.log
+
+# Temporary files
+*.tmp
+*.temp
+
+# Redis RDB files (if running locally)
+*.rdb
+
+# Environment variables
+.env
+.env.local
+.env.*.local

--- a/README.md
+++ b/README.md
@@ -9,17 +9,62 @@ A hands-on learning playground for exploring Apache Kafka and Redis integration 
 - **Spring Boot** - Java application framework
 - **Docker Compose** - Container orchestration for local development
 
+## Getting Started
+
+### Prerequisites
+- Docker and Docker Compose installed
+
+### Quick Start
+
+1. Clone the repository:
+```bash
+git clone https://github.com/toshiakisan1127/kafka-redis-playground.git
+cd kafka-redis-playground
+```
+
+2. Start the services:
+```bash
+docker-compose up -d
+```
+
+3. Verify services are running:
+```bash
+docker-compose ps
+```
+
+### Services Overview
+
+| Service | Port | Description |
+|---------|------|-------------|
+| Kafka | 9092 | Kafka broker |
+| Zookeeper | 2181 | Kafka coordination service |
+| Redis | 6379 | Redis server |
+| Kafka UI | 8080 | Web interface for Kafka (http://localhost:8080) |
+| Redis Insight | 8001 | Web interface for Redis (http://localhost:8001) |
+
+### Basic Commands
+
+```bash
+# Start all services
+docker-compose up -d
+
+# View logs
+docker-compose logs -f
+
+# Stop all services
+docker-compose down
+
+# Clean up (removes volumes)
+docker-compose down -v
+```
+
 ## Planned Features
 
+- [x] Docker environment setup
 - [ ] Kafka producer and consumer implementation
 - [ ] Redis caching strategies
 - [ ] Message processing with Kafka + Redis integration
-- [ ] Docker environment setup
 - [ ] Configuration examples and best practices
-
-## Getting Started
-
-Coming soon! This repository will include Docker Compose configurations and Spring Boot applications to demonstrate Kafka and Redis integration patterns.
 
 ## Learning Goals
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,85 @@
+version: '3.8'
+
+services:
+  # Zookeeper for Kafka
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.0
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    networks:
+      - kafka-redis-network
+
+  # Kafka Broker
+  kafka:
+    image: confluentinc/cp-kafka:7.4.0
+    hostname: kafka
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "9997:9997"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_JMX_PORT: 9997
+      KAFKA_JMX_HOSTNAME: localhost
+    networks:
+      - kafka-redis-network
+
+  # Redis
+  redis:
+    image: redis:7-alpine
+    hostname: redis
+    container_name: redis
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes
+    volumes:
+      - redis-data:/data
+    networks:
+      - kafka-redis-network
+
+  # Redis Insight (Optional - Web UI for Redis)
+  redis-insight:
+    image: redislabs/redisinsight:latest
+    container_name: redis-insight
+    ports:
+      - "8001:8001"
+    depends_on:
+      - redis
+    networks:
+      - kafka-redis-network
+
+  # Kafka UI (Optional - Web UI for Kafka)
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    depends_on:
+      - kafka
+    ports:
+      - "8080:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+    networks:
+      - kafka-redis-network
+
+volumes:
+  redis-data:
+    driver: local
+
+networks:
+  kafka-redis-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     image: redislabs/redisinsight:latest
     container_name: redis-insight
     ports:
-      - "8001:8001"
+      - "8001:5540"
     depends_on:
       - redis
     networks:


### PR DESCRIPTION
## Summary
Added Docker Compose configuration for local development environment with Kafka and Redis.

## Changes
- ✅ `docker-compose.yml` with Kafka, Zookeeper, and Redis services
- ✅ Optional web UIs (Kafka UI and Redis Insight) for easy management
- ✅ Updated README with setup instructions and service overview
- ✅ Proper networking and volume configuration

## Services Included
- **Kafka** (port 9092) with Zookeeper (port 2181)
- **Redis** (port 6379) with data persistence
- **Kafka UI** (port 8080) for Kafka management
- **Redis Insight** (port 8001) for Redis management

## How to Test
```bash
# Start services
docker-compose up -d

# Check services are running
docker-compose ps

# Access web UIs
# Kafka UI: http://localhost:8080
# Redis Insight: http://localhost:8001
```

Ready for the next step: Spring Boot application development! 🚀